### PR TITLE
Added development context menu

### DIFF
--- a/app/background/createWindow.js
+++ b/app/background/createWindow.js
@@ -1,9 +1,9 @@
 import { BrowserWindow } from 'electron'
 
-export default (url) => {
+export default ({ src }) => {
   const backgroundWindow = new BrowserWindow({
     show: false,
   })
-  backgroundWindow.loadURL(url)
+  backgroundWindow.loadURL(src)
   return backgroundWindow
 }

--- a/app/lib/config.js
+++ b/app/lib/config.js
@@ -56,7 +56,7 @@ const set = (key, value) => {
     ...JSON.parse(fs.readFileSync(CONFIG_FILE).toString())
   }
   config[key] = value
-  fs.writeFile(CONFIG_FILE, JSON.stringify(config))
+  fs.writeFileSync(CONFIG_FILE, JSON.stringify(config))
   // Track settings changes
   trackEvent({
     category: 'Settings',

--- a/app/main.development.js
+++ b/app/main.development.js
@@ -22,6 +22,8 @@ app.on('ready', () => {
     `file://${__dirname}/main/index.html`,
     // Fullpath for menu bar icon
     `${__dirname}/tray_iconTemplate@2x.png`
+    // Function to open background window dev tools
+    () => backgroundWindow.webContents.openDevTools()
   )
   backgroundWindow = createBackgroundWindow(`file://${__dirname}/background/index.html`)
 

--- a/app/main.development.js
+++ b/app/main.development.js
@@ -2,9 +2,16 @@ import { app, ipcMain, crashReporter } from 'electron'
 
 import createMainWindow from './main/createWindow'
 import createBackgroundWindow from './background/createWindow'
+import config from './lib/config'
+import AppTray from './main/createWindow/AppTray'
 
+const trayIconSrc = `${__dirname}/tray_iconTemplate@2x.png`
+const isDev = () => (
+  process.env.NODE_ENV === 'development' || config.get('developerMode')
+)
 let mainWindow
 let backgroundWindow
+let tray
 
 if (process.env.NODE_ENV !== 'development') {
   // Set up crash reporter before creating windows in production builds
@@ -17,15 +24,27 @@ if (process.env.NODE_ENV !== 'development') {
 }
 
 app.on('ready', () => {
-  mainWindow = createMainWindow(
+  mainWindow = createMainWindow({
+    isDev,
     // Main window html
-    `file://${__dirname}/main/index.html`,
-    // Fullpath for menu bar icon
-    `${__dirname}/tray_iconTemplate@2x.png`
-    // Function to open background window dev tools
-    () => backgroundWindow.webContents.openDevTools()
-  )
-  backgroundWindow = createBackgroundWindow(`file://${__dirname}/background/index.html`)
+    src: `file://${__dirname}/main/index.html`,
+  })
+
+  backgroundWindow = createBackgroundWindow({
+    src: `file://${__dirname}/background/index.html`,
+  })
+
+  tray = new AppTray({
+    src: trayIconSrc,
+    isDev: isDev(),
+    mainWindow,
+    backgroundWindow
+  })
+
+  // Show tray icon if it is set in configuration
+  if (config.get('showInTray')) {
+    tray.show()
+  }
 
   app.dock && app.dock.hide()
 })
@@ -37,4 +56,13 @@ ipcMain.on('message', (event, payload) => {
 
 ipcMain.on('updateSettings', (event, key, value) => {
   mainWindow.settingsChanges.emit(key, value)
+
+  // Show or hide menu bar icon when it is changed in setting
+  if (key === 'showInTray') {
+    value ? tray.show() : tray.hide()
+  }
+  // Show or hide "development" section in tray menu
+  if (key === 'developerMode') {
+    tray.setIsDev(isDev())
+  }
 })

--- a/app/main/createWindow.js
+++ b/app/main/createWindow.js
@@ -42,12 +42,21 @@ export default (url, trayIconSrc) => {
     mainWindow.focus()
   }
 
+  let devMenu
+  if (isDev) {
+    devMenu = [{
+      label: 'Show Developer Tools',
+      click: () => mainWindow.webContents.openDevTools()
+    }]
+  }
+
   const tray = new AppTray({
     src: trayIconSrc,
     onToggleWindow: toggleMainWindow,
     onShowSettings: () => showWindowWithTerm(mainWindow, 'settings'),
     onListPlugins: () => showWindowWithTerm(mainWindow, 'plugins'),
-    onQuit: () => app.quit()
+    onQuit: () => app.quit(),
+    template: devMenu
   })
 
   // Setup event listeners for main window

--- a/app/main/createWindow.js
+++ b/app/main/createWindow.js
@@ -14,7 +14,7 @@ import showWindowWithTerm from './createWindow/showWindowWithTerm'
 import handleUrl from './createWindow/handleUrl'
 import config from '../lib/config'
 
-export default (url, trayIconSrc) => {
+export default (url, trayIconSrc, showBackgroundDevTools) => {
   const mainWindow = new BrowserWindow({
     alwaysOnTop: true,
     width: WINDOW_WIDTH,
@@ -45,8 +45,17 @@ export default (url, trayIconSrc) => {
   let devMenu
   if (isDev) {
     devMenu = [{
-      label: 'Show Developer Tools',
-      click: () => mainWindow.webContents.openDevTools()
+      label: 'Development',
+      submenu: [{
+        label: 'DevTools (main)',
+        click: () => mainWindow.webContents.openDevTools()
+      }, {
+        label: 'DevTools (background)',
+        click: showBackgroundDevTools
+      }, {
+        label: 'Reload',
+        click: () => mainWindow.reload()
+      }]
     }]
   }
 

--- a/app/main/createWindow/AppTray.js
+++ b/app/main/createWindow/AppTray.js
@@ -9,6 +9,7 @@ export default class AppTray {
    * @param  {Function} options.onToggleWindow Handle toggle main window
    * @param  {Function} options.onShowSettings Handle show settings
    * @param  {Function} options.onQuit  Handle quit from application
+   * @param  {Array} options.template Another menu template to include
    * @return {AppTray}
    */
   constructor(options) {
@@ -23,7 +24,8 @@ export default class AppTray {
       onToggleWindow, onShowSettings, onListPlugins, onQuit, src
     } = this.options
     const tray = new Tray(src)
-    const contextMenu = Menu.buildFromTemplate([
+
+    let template = [
       {
         label: 'Toggle Cerebro',
         click: onToggleWindow
@@ -43,7 +45,14 @@ export default class AppTray {
         label: 'Quit Cerebro',
         click: onQuit
       }
-    ])
+    ]
+
+    if (this.options.template) {
+      template.push({ type: 'separator' })
+      template = template.concat(this.options.template)
+    }
+
+    const contextMenu = Menu.buildFromTemplate(template)
     tray.setToolTip('Cerebro')
     tray.setContextMenu(contextMenu)
     this.tray = tray

--- a/app/main/createWindow/buildMenu.js
+++ b/app/main/createWindow/buildMenu.js
@@ -1,6 +1,6 @@
 import { Menu, shell, app } from 'electron'
 
-export default (mainWindow, showDevOptions = false) => {
+export default (mainWindow) => {
   const template = [{
     label: 'Electron',
     submenu: [{
@@ -64,25 +64,7 @@ export default (mainWindow, showDevOptions = false) => {
     }]
   }, {
     label: 'View',
-    submenu: (showDevOptions) ? [{
-      label: 'Reload',
-      accelerator: 'Ctrl+R',
-      click() {
-        mainWindow.webContents.reload()
-      }
-    }, {
-      label: 'Toggle Full Screen',
-      accelerator: 'Ctrl+Command+F',
-      click() {
-        mainWindow.setFullScreen(!mainWindow.isFullScreen())
-      }
-    }, {
-      label: 'Toggle Developer Tools',
-      accelerator: 'Alt+Command+I',
-      click() {
-        mainWindow.toggleDevTools()
-      }
-    }] : [{
+    submenu: [{
       label: 'Toggle Full Screen',
       accelerator: 'Ctrl+Command+F',
       click() {


### PR DESCRIPTION
For whatever reason <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>I</kbd> or <kbd>F12</kbd> etc does not open dev tools on windows.  Added a (development only) context menu to enable this.