### PR TITLE
Apps search fix

### DIFF
--- a/app/main/plugins/core/apps/index.js
+++ b/app/main/plugins/core/apps/index.js
@@ -53,6 +53,7 @@ const appsPlugin = ({ term, actions, display }) => {
     ).map(file => {
       const { path, name } = file
       return {
+        id: path,
         title: name,
         term: name,
         icon: path,

--- a/app/main/plugins/core/apps/index.js
+++ b/app/main/plugins/core/apps/index.js
@@ -58,6 +58,7 @@ const appsPlugin = ({ term, actions, display }) => {
         term: name,
         icon: path,
         subtitle: path,
+        clipboard: path,
         onKeyDown: (event) => {
           if (event.metaKey && event.keyCode === 82) {
             // Show application in Finder by cmd+R shortcut

--- a/package.json
+++ b/package.json
@@ -188,7 +188,7 @@
     "webpack-visualizer-plugin": "0.1.5"
   },
   "dependencies": {
-    "cerebro-tools": "0.1.7",
+    "cerebro-tools": "0.1.8",
     "co": "4.6.0",
     "du": "0.1.0",
     "escape-string-regexp": "1.0.5",

--- a/test/plugins/apps/index.spec.js
+++ b/test/plugins/apps/index.spec.js
@@ -1,0 +1,35 @@
+import appsInjector from 'inject!../../../app/main/plugins/core/apps'
+import assert from 'assert'
+import uniq from 'lodash/uniq'
+
+const appsList = [
+  {
+    name: 'App Store',
+    filename: 'App Store.app',
+    path: '/Applications/App Store.app'
+  },
+  {
+    name: 'App Store',
+    filename: 'App Store.prefPane',
+    path: '/System/Library/PreferencePanes/AppStore.prefPane'
+  }
+]
+const getAppsList = () => Promise.resolve(appsList)
+
+const apps = appsInjector({
+  react: () => {},
+  './lib/getAppsList': getAppsList,
+  './Preview': () => {},
+})
+
+describe('OSx apps plugin', () => {
+  it('shows two apps with the same name but different paths', (done) => {
+    const term = 'App'
+    const display = (results) => {
+      const ids = results.map(file => file.id || file.title)
+      assert(uniq(ids).length === 2)
+      done()
+    }
+    apps.fn({ term, display })
+  })
+})

--- a/test/plugins/apps/index.spec.js
+++ b/test/plugins/apps/index.spec.js
@@ -32,4 +32,13 @@ describe('OSx apps plugin', () => {
     }
     apps.fn({ term, display })
   })
+
+  it('result includes clipboard key with full path', (done) => {
+    const term = 'App'
+    const display = (results) => {
+      assert(results[0].clipboard === appsList[0].path)
+      done()
+    }
+    apps.fn({ term, display })
+  })
 })


### PR DESCRIPTION
* Two apps with same name, but different paths now will be displayed
* Update cerebro-tools

Fix for #52