### PR TITLE
Hotkeys on windows and linux

### DIFF
--- a/app/main/containers/Search/index.js
+++ b/app/main/containers/Search/index.js
@@ -164,7 +164,7 @@ class Search extends Component {
     if (event.defaultPrevented) {
       return
     }
-    if (event.metaKey) {
+    if (event.metaKey || event.ctrlKey) {
       if (event.keyCode === 8) {
         // Clean search term on cmd+backspace
         this.props.actions.reset()

--- a/app/main/plugins/core/cerebro/settings/Settings/Hotkey/index.js
+++ b/app/main/plugins/core/cerebro/settings/Settings/Hotkey/index.js
@@ -65,15 +65,19 @@ const KEYCODES = {
   123: 'F12',
 }
 
+const osKeyDelimiter = process.platform === 'darwin' ? '' : '+'
 
-const keyToSign = (key) => (
-  key.replace(/control/i, '⌃')
-    .replace(/alt/i, '⌥')
-    .replace(/shift/i, '⇧')
-    .replace(/command/i, '⌘')
-    .replace(/enter/i, '↩')
-    .replace(/backspace/i, '⌫')
-)
+const keyToSign = (key) => {
+  if (process.platform === 'darwin') {
+    return key.replace(/control/i, '⌃')
+      .replace(/alt/i, '⌥')
+      .replace(/shift/i, '⇧')
+      .replace(/command/i, '⌘')
+      .replace(/enter/i, '↩')
+      .replace(/backspace/i, '⌫')
+  }
+  return key
+}
 
 const charCodeToSign = ({ keyCode, shiftKey }) => {
   const code = ASCII[keyCode] ? ASCII[keyCode] : keyCode
@@ -122,7 +126,7 @@ export default class Hotkey extends Component {
   }
   render() {
     const { hotkey } = this.props
-    const keys = hotkey.split('+').map(keyToSign).join('')
+    const keys = hotkey.split('+').map(keyToSign).join(osKeyDelimiter)
     return (
       <div className={styles.hotkey}>
         <input

--- a/app/main/plugins/core/files/index.js
+++ b/app/main/plugins/core/files/index.js
@@ -49,7 +49,7 @@ const filesPlugin = ({ term, actions, display }) => {
           term: autocomplete,
           icon: filePath,
           onKeyDown: (event) => {
-            if (event.metaKey && event.keyCode === 82) {
+            if ((event.metaKey || event.ctrlKey) && event.keyCode === 82) {
               actions.reveal(filePath)
               event.preventDefault()
             }

--- a/app/main/plugins/core/osx-apps/index.js
+++ b/app/main/plugins/core/osx-apps/index.js
@@ -60,7 +60,7 @@ const appsPlugin = ({ term, actions, display }) => {
         subtitle: path,
         clipboard: path,
         onKeyDown: (event) => {
-          if (event.metaKey && event.keyCode === 82) {
+          if ((event.metaKey || event.ctrlKey) && event.keyCode === 82) {
             // Show application in Finder by cmd+R shortcut
             actions.reveal(path)
             event.preventDefault()

--- a/docs/plugins/plugin-structure.md
+++ b/docs/plugins/plugin-structure.md
@@ -97,11 +97,11 @@ Type: `Function`
 
 Arguments: `event: Event`
 
-Handle keyboard events when your result is focused, so you can do custom actions, i.e. reveal file in finder by <kbd>cmd+r</kbd>:
+Handle keyboard events when your result is focused, so you can do custom actions, i.e. reveal file in finder by <kbd>cmd+r</kbd> (or <kbd>ctrl+r</kbd> on windows and linux):
 
 ```js
 onKeyDown: (event) => {
-  if (event.metaKey && event.keyCode === 82) {
+  if ((event.metaKey || event.ctrlKey) && event.keyCode === 82) {
     actions.reveal(path);
     event.preventDefault();
   }


### PR DESCRIPTION
* Copy to clipboard by ctrl+c
* Reveal by ctrl+r
* Do not show MacOS key symbols on linux and windows 

Fix for #61 and #37