### PR TITLE
Improve window position and size

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@ coverage
 # Grunt intermediate storage (http://gruntjs.com/creating-plugins#storing-task-files)
 .grunt
 
+# Tern-js work files
+.tern-port
+
 # node-waf configuration
 .lock-wscript
 

--- a/app/lib/getWindowPosition.js
+++ b/app/lib/getWindowPosition.js
@@ -1,0 +1,57 @@
+import { screen } from 'electron'
+import config from './config'
+
+import {
+  WINDOW_WIDTH,
+  INPUT_HEIGHT,
+  RESULT_HEIGHT,
+  MIN_VISIBLE_RESULTS,
+} from '../main/constants/ui'
+
+
+/**
+ * Returns true if a window is at least partially visible on the display
+ */
+const isVisible = (windowBounds, displayBounds) =>
+  !(windowBounds.x > displayBounds.x + displayBounds.width ||
+    windowBounds.x + windowBounds.width < displayBounds.x ||
+    windowBounds.y > displayBounds.y + displayBounds.height ||
+    windowBounds.y + windowBounds.height < displayBounds.y)
+
+
+/**
+ * Computes window position
+ */
+export default ({ width, heightWithResults }) => {
+  const winWidth = typeof width !== 'undefined' ? width : WINDOW_WIDTH
+  const winHeight = typeof heightWithResults !== 'undefined'
+    ? heightWithResults
+    : MIN_VISIBLE_RESULTS * RESULT_HEIGHT + INPUT_HEIGHT
+
+  const display = screen.getPrimaryDisplay()
+  const positions = config.get('positions') || {}
+
+  if (display.id in positions) {
+    const [x, y] = positions[display.id]
+    const windowBounds = { x, y, winWidth, winHeight }
+    const isWindowVisible = (disp) => isVisible(windowBounds, disp.bounds)
+
+    if (isWindowVisible(display)) {
+      return [x, y]
+    }
+
+    // The window was moved from the primary screen to a different one.
+    // We have to check that the window will be visible somewhere among the attached displays.
+    const displays = screen.getAllDisplays()
+    const isVisibleSomewhere = displays.some(isWindowVisible)
+
+    if (isVisibleSomewhere) {
+      return [x, y]
+    }
+  }
+
+  const x = parseInt(display.bounds.x + (display.workAreaSize.width - winWidth) / 2, 10)
+  const y = parseInt(display.bounds.y + (display.workAreaSize.height - winHeight) / 2, 10)
+  return [x, y]
+}
+

--- a/app/main/containers/Search/index.js
+++ b/app/main/containers/Search/index.js
@@ -14,6 +14,7 @@ import escapeStringRegexp from 'escape-string-regexp'
 import { debounce, bind } from 'lodash-decorators'
 
 import trackEvent from 'lib/trackEvent'
+import config from 'lib/config'
 
 import {
   WINDOW_WIDTH,
@@ -111,6 +112,7 @@ class Search extends Component {
     this.electronWindow.on('show', this.focusMainInput)
     this.electronWindow.on('show', this.updateElectronWindow)
     this.electronWindow.on('show', trackShowWindow)
+    this.electronWindow.on('move', this.moveElectronWindow)
   }
   componentDidMount() {
     this.focusMainInput()
@@ -305,22 +307,67 @@ class Search extends Component {
     // When results list is empty window is not resizable
     win.setResizable(length !== 0)
 
-    const winResultMinHeight = INPUT_HEIGHT + RESULT_HEIGHT * MIN_VISIBLE_RESULTS
-    let winResultHeight = winResultMinHeight
+    const minHeightWithResults = INPUT_HEIGHT + RESULT_HEIGHT * MIN_VISIBLE_RESULTS
+    let heightWithResults = minHeightWithResults
+    let height = INPUT_HEIGHT
 
     if (length === 0) {
-      win.setMinimumSize(WINDOW_WIDTH, INPUT_HEIGHT)
-      win.setSize(width, INPUT_HEIGHT)
+      win.setMinimumSize(WINDOW_WIDTH, height)
+      win.setSize(width, height)
     } else {
       const resultHeight = Math.max(Math.min(visibleResults, length), MIN_VISIBLE_RESULTS)
-      winResultHeight = resultHeight * RESULT_HEIGHT + INPUT_HEIGHT
-      win.setMinimumSize(WINDOW_WIDTH, winResultMinHeight)
-      win.setSize(width, winResultHeight)
+      height = heightWithResults = resultHeight * RESULT_HEIGHT + INPUT_HEIGHT
+      win.setMinimumSize(WINDOW_WIDTH, minHeightWithResults)
+      win.setSize(width, height)
+    }
+
+    const positions = config.get('positions') || {}
+    if (display.id in positions) {
+      const [x, y] = positions[display.id]
+      const windowBounds = { x, y, width, height }
+      const isWindowVisible = (disp) => this.isVisible(windowBounds, disp.bounds)
+
+      if (isWindowVisible(display)) {
+        this.electronWindow.setPosition(x, y)
+        return
+      }
+
+      // The window was moved from the primary screen to a different one.
+      // We have to check that the window will be visible somewhere among the attached displays.
+      const displays = screen.getAllDisplays()
+      const isVisibleSomewhere = displays.some(isWindowVisible)
+
+      if (isVisibleSomewhere) {
+        this.electronWindow.setPosition(x, y)
+        return
+      }
     }
 
     const x = parseInt(display.bounds.x + (display.workAreaSize.width - width) / 2, 10)
-    const y = parseInt(display.bounds.y + (display.workAreaSize.height - winResultHeight) / 2, 10)
+    const y = parseInt(display.bounds.y + (display.workAreaSize.height - heightWithResults) / 2, 10)
     this.electronWindow.setPosition(x, y)
+  }
+
+  /**
+   * Returns true if a window is at least partially visible on the display
+   */
+  isVisible(windowBounds, displayBounds) {
+    return !(windowBounds.x > displayBounds.x + displayBounds.width ||
+             windowBounds.x + windowBounds.width < displayBounds.x ||
+             windowBounds.y > displayBounds.y + displayBounds.height ||
+             windowBounds.y + windowBounds.height < displayBounds.y)
+  }
+
+  /**
+   * Saves window position when it is being moved
+   */
+  @bind()
+  @debounce(100)
+  moveElectronWindow() {
+    const display = screen.getPrimaryDisplay()
+    const positions = config.get('positions') || {}
+    positions[display.id] = this.electronWindow.getPosition()
+    config.set('positions', positions)
   }
 
   autocompleteValue() {

--- a/app/main/containers/Search/index.js
+++ b/app/main/containers/Search/index.js
@@ -305,20 +305,21 @@ class Search extends Component {
     // When results list is empty window is not resizable
     win.setResizable(length !== 0)
 
-    let height = INPUT_HEIGHT
+    const winResultMinHeight = INPUT_HEIGHT + RESULT_HEIGHT * MIN_VISIBLE_RESULTS
+    let winResultHeight = winResultMinHeight
+
     if (length === 0) {
-      win.setMinimumSize(WINDOW_WIDTH, height)
-      win.setSize(width, height)
+      win.setMinimumSize(WINDOW_WIDTH, INPUT_HEIGHT)
+      win.setSize(width, INPUT_HEIGHT)
     } else {
-      const minHeight = INPUT_HEIGHT + RESULT_HEIGHT * MIN_VISIBLE_RESULTS
       const resultHeight = Math.max(Math.min(visibleResults, length), MIN_VISIBLE_RESULTS)
-      height = resultHeight * RESULT_HEIGHT + INPUT_HEIGHT
-      win.setMinimumSize(WINDOW_WIDTH, minHeight)
-      win.setSize(width, height)
+      winResultHeight = resultHeight * RESULT_HEIGHT + INPUT_HEIGHT
+      win.setMinimumSize(WINDOW_WIDTH, winResultMinHeight)
+      win.setSize(width, winResultHeight)
     }
 
     const x = parseInt(display.bounds.x + (display.workAreaSize.width - width) / 2, 10)
-    const y = parseInt(display.bounds.y + (display.workAreaSize.height - height) / 2, 10)
+    const y = parseInt(display.bounds.y + (display.workAreaSize.height - winResultHeight) / 2, 10)
     this.electronWindow.setPosition(x, y)
   }
 


### PR DESCRIPTION
I'll start with a demonstration of how the positioning and sizing actually works today on my box:

* Initially Cerebro window is small and centered
* Start typing and window expands over the boundary of my screen
* Hit Enter to run the selected app
* Next time I open Cerebro, the window is large
* Type and remove a character makes window small again, but not centered
* Next time I open Cerebro, the window is again small and centered

![cerebro-before](https://cloud.githubusercontent.com/assets/1177900/22569052/6b31f370-e996-11e6-9c9e-a95a12a6ad28.gif)

It is easy to fix the incorrectly large size on startup, but what to do with window expanding over the boundary of my screen when I start typing something...

I've got two basic ideas:
* Place the Cerebro window not in the center, but closer to the top of the screen. That way, there's a bit more available space for the window to grow.
* Always maintain Cerebro window centered, regardless of its size.

I'm actually not sure which of these is better. I think the second one is a bit more elegant. What do you think, @KELiON? Maybe you can come up with a third option?

This pull request demonstrates the second option, keeping window always centered. It looks like this:

![cerebro-after](https://cloud.githubusercontent.com/assets/1177900/22569352/872a6eee-e997-11e6-9129-d6d4a3567b20.gif)


By the way, this pull request also attempts to fix #35 and #33.

On my laptop the code from `master` branch places the Cerebro window in the center of the _active_ screen. However, judging by the issues above, this is not the case for many people on different OS. 

Unfortunately there is no Electron API to determine the _active_ screen, only the _primary_ one. On Linux, the primary screen can be set via `xrandr --output XXX --primary`. The code in this branch places the Cerebro window in the center of the _primary_ screen.