### PR TITLE
Linking linux-commands plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![Build Status][travis-image]][travis-url]
 [![Dependency Status][david_img]][david_site]
-[![OpenCollective](https://opencollective.com/cerebro/backers/badge.svg)](#backers) 
+[![OpenCollective](https://opencollective.com/cerebro/backers/badge.svg)](#backers)
 [![OpenCollective](https://opencollective.com/cerebro/sponsors/badge.svg)](#sponsors)
 
 ## Usage
@@ -38,6 +38,7 @@ Use built-in `plugins` command to search and manage custom plugins.
 * [IP](https://github.com/KELiON/cerebro-ip) – show your local & external IP address;
 * [Kill](https://github.com/KELiON/cerebro-kill) – kill process by name, i.e. `kill cerebro`;
 * [Shell](https://github.com/KELiON/cerebro-shell) – exec shell commands without running terminal;
+* [Linux Commands](https://github.com/mckennajones/cerebro-linux-commands) - System commands in Linux i.e. `sleep`, `restart`, `empty trash`, `shut down`
 
 ## Development
 ### Create plugin


### PR DESCRIPTION
I am linking a small plugin that I created which is essentially the same as OSx-system but for Linux.
 
I originally called my plugin cerebro-linux-system, but right when I was about to publish mine I realized that someone else had already published a plugin by that name on npm. 

However, I believe that mine is superior from cerebro-linux-system in a couple ways. First of all, it does not depend on the gksudo command which many people do not have installed by default. Instead my README documents how to edit the /etc/sudoers file instead. Similarly it does not depend on the pm-utils package which is often not on all Linux systems. 

There is no way to create a plugin like this that will work on all Linux systems, but I think mine will work on 90%.

Been loving Cerebro so far, thanks!