### PR TITLE
Support more languages in translate plugin

### DIFF
--- a/app/main/plugins/core/translate/Preview/index.js
+++ b/app/main/plugins/core/translate/Preview/index.js
@@ -5,11 +5,12 @@ import translate from '../translate'
 import getTargetLanguage from '../getTargetLanguage'
 import { LANGS, DISPLAY_NAMES } from '../constants'
 import { bind } from 'lodash-decorators'
+import sortBy from 'lodash/sortBy'
 import Select from 'react-select'
 import styles from './styles.css'
 
 
-const OPTIONS = LANGS.map(lang => ({
+const OPTIONS = sortBy(LANGS, lang => DISPLAY_NAMES[lang]).map(lang => ({
   value: lang,
   label: DISPLAY_NAMES[lang]
 }))

--- a/app/main/plugins/core/translate/constants.js
+++ b/app/main/plugins/core/translate/constants.js
@@ -29,6 +29,89 @@ export const SYNONIMS = {
 
   'fra*': 'fr',
   'фра*': 'fr',
+
+  'голлан*': 'nl',
+  'dutc*': 'nl',
+
+  'pers*': 'fa',
+  'перс*': 'fa',
+
+  'укра*': 'uk',
+  'ukra*': 'uk',
+
+  'catal*': 'ca',
+  'катал*': 'ca',
+
+  'chin*': 'zh',
+  'кита*': 'zh',
+
+  'arab*': 'ar',
+  'араб*': 'ar',
+
+  'belarus*': 'be',
+  'белорус*': 'be',
+
+  'hungar*': 'hu',
+  'венгер*': 'hu',
+
+  'viet*': 'vi',
+  'вьет*': 'vi',
+
+  'дастк*': 'da',
+
+  'hebr*': 'he',
+  'иври*': 'he',
+
+  'идиш*': 'yi',
+  'yidd*': 'yi',
+
+  'indones*': 'id',
+  'индонез*': 'id',
+
+  'ирлан*': 'ga',
+
+  'icela*': 'is',
+  'ислан*': 'is',
+
+  'казах*': 'kz',
+  'киргиз*': 'ky',
+
+  'корей*': 'ko',
+  'korea*': 'ko',
+
+  'latv*': 'lv',
+  'латв*': 'lv',
+
+  'lith*': 'lt',
+  'литов*': 'lt',
+
+  'norw*': 'no',
+  'норв*': 'no',
+
+  'польск*': 'pl',
+
+  'portug*': 'pt',
+  'португ*': 'pt',
+
+  'румын*': 'ro',
+
+  'словац*': 'sk',
+
+  'sloven*': 'sl',
+  'словен*': 'sl',
+
+  'тай*': 'th',
+  'турец*': 'tr',
+
+  'finni*': 'fi',
+  'финск*': 'fi',
+
+  'чешс*': 'cs',
+  'шведс*': 'sv',
+
+  'эстон*': 'et',
+  'эсперан*': 'eo',
+  'япон*': 'ja'
 }
 
 
@@ -44,7 +127,42 @@ export const DISPLAY_NAMES = {
   es: 'Spanish',
   it: 'Italian',
   de: 'German',
-  fr: 'French'
+  fr: 'French',
+  nl: 'Dutch',
+  fa: 'Persian',
+  uk: 'Ukrainian',
+  ca: 'Catalan',
+  zh: 'Chinese',
+  ar: 'Arab',
+  be: 'Belarusian',
+  hu: 'Hungarian',
+  vi: 'Vietnamese',
+  da: 'Danish',
+  he: 'Hebrew',
+  yi: 'Yiddish',
+  id: 'Indonesian',
+  ga: 'Irish',
+  is: 'Icelandic',
+  kk: 'Kazakh',
+  ky: 'Kyrgyz',
+  ko: 'Korean',
+  lv: 'Latvian',
+  lt: 'Lithuanian',
+  no: 'Norwegian',
+  pl: 'Polish',
+  pt: 'Portuguese',
+  ro: 'Romanian',
+  sk: 'Slovak',
+  sl: 'Slovenian',
+  th: 'Thai',
+  tr: 'Turkish',
+  fi: 'Finnish',
+  hi: 'Hindi',
+  cs: 'Czech',
+  sv: 'Swedish',
+  et: 'Estonian',
+  eo: 'Esperanto',
+  ja: 'Japanese'
 }
 
 /**


### PR DESCRIPTION
List of added languages:

* French
* Dutch
* Persian
* Ukrainian
* Catalan
* Chinese
* Arab
* Belarusian
* Hungarian
* Vietnamese
* Danish
* Hebrew
* Yiddish
* Indonesian
* Irish
* Icelandic
* Kazakh
* Kyrgyz
* Korean
* Latvian
* Lithuanian
* Norwegian
* Polish
* Portuguese
* Romanian
* Slovak
* Slovenian
* Thai
* Turkish
* Finnish
* Hindi
* Czech
* Swedish
* Estonian
* Esperanto
* Japanese

Fix #64 