### PR TITLE
Fix js error popup

### DIFF
--- a/app/main/containers/Search/index.js
+++ b/app/main/containers/Search/index.js
@@ -242,6 +242,7 @@ class Search extends Component {
     window.removeEventListener('keydown', this.onDocumentKeydown)
     window.removeEventListener('beforeunload', this.cleanup)
     this.electronWindow.removeListener('show', this.focusMainInput)
+    this.electronWindow.removeListener('show', this.updateElectronWindow)
     this.electronWindow.removeListener('show', trackShowWindow)
   }
 


### PR DESCRIPTION
Fix #90 "Error: Attempting to call a function in a renderer window that has been closed or released." after the main window reload.

@maximbaz we forgot about it in your PR