### PR TITLE
Hide empty preview and use all width for results in this case

### DIFF
--- a/app/main/components/ResultsList/Row/styles.css
+++ b/app/main/components/ResultsList/Row/styles.css
@@ -58,6 +58,5 @@
   flex-direction: column;
   align-items: flex-start;
   justify-content: center;
-  max-width: 225px;
   height: 90%;
 }

--- a/app/main/components/ResultsList/index.js
+++ b/app/main/components/ResultsList/index.js
@@ -4,10 +4,7 @@ import styles from './styles.css'
 import { VirtualScroll } from 'react-virtualized'
 import { bind } from 'lodash-decorators'
 
-import {
-  RESULT_HEIGHT,
-  RESULT_WIDTH
-} from '../../constants/ui'
+import { RESULT_HEIGHT } from '../../constants/ui'
 
 export default class ResultsList extends Component {
   static propTypes = {
@@ -77,7 +74,7 @@ export default class ResultsList extends Component {
           rowCount={results.length}
           rowHeight={RESULT_HEIGHT}
           rowRenderer={this.rowRenderer}
-          width={RESULT_WIDTH}
+          width={10000}
           scrollToIndex={selected}
           // Needed to force update of VirtualScroll
           titles={results.map(result => result.title)}

--- a/app/main/components/ResultsList/styles.css
+++ b/app/main/components/ResultsList/styles.css
@@ -4,6 +4,7 @@
   flex-wrap: nowrap;
   border-top: var(--main-border);
   height: 100%;
+  position: relative;
 }
 
 .unfocused {
@@ -12,17 +13,22 @@
 
 .resultsList {
   overflow-y: auto;
-  width: 250px;
+  width: 100%;
   min-width: 250px;
 }
 
 .preview {
   flex-grow: 2;
   padding: 10px 10px 20px 10px;
+  background-color: var(--main-background-color);
   align-items: center;
   display: flex;
   max-height: 100%;
-  position: relative;
+  position: absolute;
+  left: 250px;
+  top: 0;
+  bottom: 0;
+  right: 0;
   overflow: auto;
   /*
     Instead of using `justify-content: center` we have to use this hack.
@@ -32,6 +38,10 @@
   &::before, &::after {
     content: '';
     margin: auto;
+  }
+
+  &:empty {
+    display: none;
   }
 
   input {

--- a/app/main/constants/ui.js
+++ b/app/main/constants/ui.js
@@ -4,9 +4,6 @@ export const INPUT_HEIGHT = 45
 // Heigth of default result line
 export const RESULT_HEIGHT = 45
 
-// Heigth of default result line
-export const RESULT_WIDTH = 250
-
 // Width of main window
 export const WINDOW_WIDTH = 650
 


### PR DESCRIPTION
Implement #99

![](http://g.recordit.co/UQjtSAeb8j.gif)