### PR TITLE
Use more stable approach for unarchiving plugins

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -18,7 +18,6 @@
     "nodobjc": "^2.1.0",
     "rmdir": "^1.2.0",
     "semver": "^5.3.0",
-    "tar.gz": "1.0.2",
     "universal-analytics": "^0.4.8"
   },
   "devDependencies": {}

--- a/package.json
+++ b/package.json
@@ -214,7 +214,8 @@
     "react-virtualized": "https://registry.npmjs.org/react-virtualized/-/react-virtualized-7.11.8.tgz",
     "redux": "3.5.2",
     "redux-thunk": "2.1.0",
-    "source-map-support": "0.4.0"
+    "source-map-support": "0.4.0",
+    "tar-fs": "1.15.0"
   },
   "devEngines": {
     "node": ">=6.x"


### PR DESCRIPTION
Using `tar.gz` is unpredictable: sometimes it doesn't unarchive some files without raising an error. In this case plugin shown as installed, but it doesn't work, because not all files are included. 

This approach after some tests feels more stable