### PR TITLE
Add Indian rupee

### DIFF
--- a/app/main/plugins/core/converter/currency/constants.js
+++ b/app/main/plugins/core/converter/currency/constants.js
@@ -75,7 +75,8 @@ export const CURRENCY_BY_COUNTRY = {
   'TF': 'eur',
   'VA': 'eur',
   'YT': 'eur',
-  'IL': 'ils'
+  'IL': 'ils',
+  'IN': 'inr'
 }
 
 /**
@@ -116,6 +117,10 @@ export const SYNONIMS = {
 
   'форинт*': 'huf',
   'forint*': 'huf',
+
+  '₹': 'inr',
+  'rs': 'inr',
+  'rupee*': 'inr',
 
   'ringgit*': 'myr',
   'ринггит*': 'myr',
@@ -179,5 +184,6 @@ export const DISPLAY_NAMES = {
   'uah': '₴',
   'ils': '₪',
   'chf': '₣',
-  'thb': '฿'
+  'thb': '฿',
+  'inr': '₹'
 }


### PR DESCRIPTION
I added some keys to `currency/constants.js` to support the Indian rupee.

- [x] Map against the country (`CURRENCY_BY_COUNTRY`)
- [x] Recognize synonyms (`SYNONIMS`)
- [x] Add the display symbol (`DISPLAY_NAMES`)

One problem I ran into, is that synonyms work for the plain text values `rs` and `rupee*`, but not for the currency symbol `₹`. Typing e.g. <kbd>47 ₹</kbd> or <kbd>21 $ in ₹</kbd> doesn't do anything. Any ideas?