### PR TITLE
Save window position only when it's visible

### DIFF
--- a/app/main/createWindow.js
+++ b/app/main/createWindow.js
@@ -57,6 +57,9 @@ export default ({ src, isDev }) => {
 
   // Save window position when it is being moved
   mainWindow.on('move', debounce(() => {
+    if (!mainWindow.isVisible()) {
+      return
+    }
     const display = screen.getPrimaryDisplay()
     const positions = config.get('positions') || {}
     positions[display.id] = mainWindow.getPosition()


### PR DESCRIPTION
A small bug fix, steps to reproduce:

- Open cerebro, move the window somewhere and hide it
- Switch to chrome, enter full screen
- Hit the hotkey to open cerebro (you don't see it, but it is opened behind the chrome)
- Hit the hotkey again to close cerebro
- Exit from the chrome full screen
- Hit the hotkey to open cerebro again

Expected: the position is the same as where you moved it on the first step.
Actual: the position is lost, the window is centered.

Update: according to #39 it might be Linux related, or even window manager related issue.