### PR TITLE
Do not raise global exception if machine-id is not found

### DIFF
--- a/app/lib/trackEvent.js
+++ b/app/lib/trackEvent.js
@@ -2,8 +2,16 @@ import ua from 'universal-analytics'
 import { machineIdSync } from 'node-machine-id'
 
 const DEFAULT_CATEGORY = 'Cerebro App'
-const visitor = ua('UA-87361302-1', machineIdSync(), { strictCidFormat: false })
+
 const trackingEnabled = process.env.NODE_ENV === 'production'
+let visitor
+
+try {
+  visitor = ua('UA-87361302-1', machineIdSync(), { strictCidFormat: false })
+} catch (err) {
+  console.log('[machine-id error]', err)
+  visitor = ua('UA-87361302-1')
+}
 
 export default ({ category, event, label, value }) => {
   if (trackingEnabled) {


### PR DESCRIPTION
Cerebro should work when something goes wrong in `node-machine-id`

Fix for #174 and #124