### PR TITLE
Add DuckDuckGo plugin to Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Use built-in `plugins` command to search and manage custom plugins.
 #### Plugins for all platforms
 * [Caniuse](https://github.com/KELiON/cerebro-caniuse) – quick access to [caniuse.com](http://caniuse.com) database;
 * [Devdocs](https://github.com/KELiON/cerebro-devdocs) – search in dev. documentations provided by [devdocs.io](http://devdocs.io)
+* [DuckDuckGo](https://github.com/tiagoamaro/cerebro-duck-duck-go) – Use DuckDuckGo as your search engine;
 * [Emoj](https://github.com/KELiON/cerebro-emoj) – search for relevant emoji, like `emoj this is awesome`;
 * [Gif](https://github.com/KELiON/cerebro-gif) – search for relevant gif, i.e. `gif luck`, `how i met your mother gif`;
 * [Google Knowledge Graph](https://github.com/Kageetai/cerebro-gkg) – Get info from the [Google Knowledge Graph](https://www.google.com/intl/bn/insidesearch/features/search/knowledge.html) for your query;


### PR DESCRIPTION
Hello @KELiON,

First, thank you very much for Cerebro! It's an incredible piece of software (clean code and easy to extend 👏👏👏).

This PR aims to add the DuckDuckGo plugin as a search engine to Cerebro's README file.