### PR TITLE
Fix plugins search

### DIFF
--- a/app/main/plugins/core/cerebro/plugins/getAvailablePlugins.js
+++ b/app/main/plugins/core/cerebro/plugins/getAvailablePlugins.js
@@ -2,7 +2,7 @@
  * API endpoint to search all cerebro plugins
  * @type {String}
  */
-const URL = 'https://api.npms.io/v2/search?from=0&q=keywords%3Acerebro-plugin'
+const URL = 'https://api.npms.io/v2/search?from=0&q=keywords%3Acerebro-plugin&size=250'
 
 /**
  * Get all available plugins for Cerebro


### PR DESCRIPTION
There are more than 25 published plugins now and not all of them are visible in plugins list. 

This PR will fix this problem while we have less than 250 plugins, that is maximum available value for `size` query parameter. After that we should add pagination