### PR TITLE
Use NPM’s registry to search for plugins

### DIFF
--- a/app/main/plugins/core/cerebro/plugins/getAvailablePlugins.js
+++ b/app/main/plugins/core/cerebro/plugins/getAvailablePlugins.js
@@ -2,7 +2,7 @@
  * API endpoint to search all cerebro plugins
  * @type {String}
  */
-const URL = 'https://api.npms.io/v2/search?from=0&q=keywords%3Acerebro-plugin'
+const URL = 'https://registry.npmjs.com/-/v1/search?from=0&size=500&text=keywords:cerebro-plugin'
 
 /**
  * Get all available plugins for Cerebro
@@ -11,7 +11,7 @@ const URL = 'https://api.npms.io/v2/search?from=0&q=keywords%3Acerebro-plugin'
 export default () => (
   fetch(URL)
     .then(response => response.json())
-    .then(json => json.results.map(p => ({
+    .then(json => json.objects.map(p => ({
       name: p.package.name,
       version: p.package.version,
       description: p.package.description,


### PR DESCRIPTION
Hi @KELiON,

I noticed some of the newly developed plugins for Cerebro weren't available ASAP on its plugin search. I dug down the codebase and Github issues to see if someone had had this issue before, and found #79.

Based on #79, I've searched around for an official NPM registry search docs. It seems they've recently developed an API for their registry and properly documented: https://github.com/npm/registry/blob/956a880ec395d10ccc717e78c0a4fd56cf9356a4/docs/REGISTRY-API.md. As you can see, its docs date Jan 26.

This PR introduces a quick change on how Cerebro search for its plugins. Instead of using `npms.io`, it now uses the official npm registry, searching for the same `cerebro-plugin` keyword.