### PR TITLE
Remove overriding font-family declaration in Settings

### DIFF
--- a/app/main/plugins/core/cerebro/settings/Settings/styles.css
+++ b/app/main/plugins/core/cerebro/settings/Settings/styles.css
@@ -3,7 +3,6 @@
   align-self: flex-start;
   flex-direction: column;
   align-items: center;
-  font-family: "Helvetica Neue";
 }
 
 .item {


### PR DESCRIPTION
@Razzile pointed out in #155 that the Settings plugin was using `Helvetica Neue` as the `font-family`, which isn't installed by default on operating systems other than macOS. I removed the declaration so that it falls back to `system-font-css` and picks up the OS default.

This works on elementary OS, but need someone to check if things are fine on macOS and Windows as well.