### PR TITLE
Quit application when main window is closed

### DIFF
--- a/app/main/createWindow.js
+++ b/app/main/createWindow.js
@@ -68,6 +68,8 @@ export default ({ src, isDev }) => {
     config.set('positions', positions)
   }, 100))
 
+  mainWindow.on('close', app.quit)
+
   mainWindow.webContents.on('new-window', (event, url) => {
     shell.openExternal(url)
     event.preventDefault()


### PR DESCRIPTION
On mac you can close main window with cmd+w (or alt+f4 on windows). Previously it caused an error when you use cerebro shortcut next

Fix for #46