### PR TITLE
Split plugins into categories

### DIFF
--- a/app/main/plugins/core/cerebro/plugins/index.js
+++ b/app/main/plugins/core/cerebro/plugins/index.js
@@ -6,9 +6,15 @@ import loadPlugins from './loadPlugins'
 import icon from '../icon.png'
 import * as format from './format'
 import { flow, map, partialRight, tap } from 'lodash/fp'
+import { partition } from 'lodash'
 import initializeAsync from './initializeAsync'
 
 const toString = ({ name, description }) => [name, description].join(' ')
+const categories = [
+  ['Updates', plugin => plugin.isUpdateAvailable],
+  ['Installed', plugin => plugin.isInstalled],
+  ['Available', plugin => plugin.name],
+]
 
 const updatePlugin = (update, name) => {
   loadPlugins().then(plugins => {
@@ -26,20 +32,42 @@ const updatePlugin = (update, name) => {
   })
 }
 
-const pluginToResult = update => plugin => ({
-  icon,
-  id: plugin.name,
-  title: `${format.name(plugin.name)} (${format.version(plugin)})`,
-  subtitle: format.description(plugin.description),
-  onSelect: () => shell.openExternal(plugin.repo),
-  getPreview: () => (
-    <Preview
-      {...plugin}
-      key={plugin.name}
-      onComplete={() => updatePlugin(update, plugin.name)}
-    />
-  )
-})
+const pluginToResult = update => plugin => {
+  if (typeof plugin === 'string') {
+    return { title: plugin }
+  }
+
+  return {
+    icon,
+    id: plugin.name,
+    title: `${format.name(plugin.name)} (${format.version(plugin)})`,
+    subtitle: format.description(plugin.description),
+    onSelect: () => shell.openExternal(plugin.repo),
+    getPreview: () => (
+      <Preview
+        {...plugin}
+        key={plugin.name}
+        onComplete={() => updatePlugin(update, plugin.name)}
+      />
+    )
+  }
+}
+
+const categorize = (plugins, callback) => {
+  const result = []
+  let remainder = plugins
+
+  categories.forEach(category => {
+    const [title, filter] = category
+    const [matched, others] = partition(remainder, filter)
+    if (matched.length) result.push(title, ...matched)
+    remainder = others
+  })
+
+  plugins.splice(0, plugins.length)
+  plugins.push(...result)
+  callback()
+}
 
 const fn = ({ term, display, hide, update }) => {
   const match = term.match(/^plugins?\s*(.+)?$/i)
@@ -51,8 +79,8 @@ const fn = ({ term, display, hide, update }) => {
     })
     loadPlugins().then(flow(
       partialRight(search, [match[1], toString]),
+      tap(plugins => categorize(plugins, () => hide('loading'))),
       map(pluginToResult(update)),
-      tap(() => hide('loading')),
       display
     ))
   }


### PR DESCRIPTION
So I took a crack at fixing #200.

This is what it looks like 
<img width="835" alt="cerebro-plugins-categories" src="https://cloud.githubusercontent.com/assets/1738373/23551294/10b788d8-0016-11e7-8950-f5577dcf5c99.png">

Platform specific categories can be added too.
Any reservations about the way it was implemented? The functional style was a bit difficult to adjust to, but it's good.

Fixes #200
