### PR TITLE
Race condition: allow a second before trying to load the plugin

### DIFF
--- a/app/main/plugins/externalPlugins.js
+++ b/app/main/plugins/externalPlugins.js
@@ -45,25 +45,27 @@ pluginsWatcher.on('addDir', (pluginPath) => {
   if (dir !== modulesDirectory) {
     return
   }
-  console.group(`Load plugin: ${base}`)
-  console.log(`Path: ${pluginPath}...`)
-  const plugin = requirePlugin(pluginPath)
-  if (!isPluginValid(plugin)) {
-    console.log('Plugin is not valid, skipped')
+  setTimeout(() => {
+    console.group(`Load plugin: ${base}`)
+    console.log(`Path: ${pluginPath}...`)
+    const plugin = requirePlugin(pluginPath)
+    if (!isPluginValid(plugin)) {
+      console.log('Plugin is not valid, skipped')
+      console.groupEnd()
+      return
+    }
+    console.log('Loaded.')
+    const requirePath = window.require.resolve(pluginPath)
+    const watcher = chokidar.watch(requirePath, { depth: 0 })
+    watcher.on('change', () => {
+      console.log(`[${base}] Update plugin`)
+      delete window.require.cache[requirePath]
+      plugins[base] = window.require(pluginPath)
+      console.log(`[${base}] Plugin updated`)
+    })
     console.groupEnd()
-    return
-  }
-  console.log('Loaded.')
-  const requirePath = window.require.resolve(pluginPath)
-  const watcher = chokidar.watch(requirePath, { depth: 0 })
-  watcher.on('change', () => {
-    console.log(`[${base}] Update plugin`)
-    delete window.require.cache[requirePath]
-    plugins[base] = window.require(pluginPath)
-    console.log(`[${base}] Plugin updated`)
-  })
-  console.groupEnd()
-  plugins[base] = plugin
+    plugins[base] = plugin
+  }, 1000)
 })
 
 export default plugins

--- a/app/main/plugins/externalPlugins.js
+++ b/app/main/plugins/externalPlugins.js
@@ -1,3 +1,4 @@
+import debounce from 'lodash/debounce'
 import chokidar from 'chokidar'
 import path from 'path'
 import { modulesDirectory, ensureFiles } from 'lib/plugins'
@@ -57,12 +58,12 @@ pluginsWatcher.on('addDir', (pluginPath) => {
     console.log('Loaded.')
     const requirePath = window.require.resolve(pluginPath)
     const watcher = chokidar.watch(requirePath, { depth: 0 })
-    watcher.on('change', () => {
+    watcher.on('change', debounce(() => {
       console.log(`[${base}] Update plugin`)
       delete window.require.cache[requirePath]
       plugins[base] = window.require(pluginPath)
       console.log(`[${base}] Plugin updated`)
-    })
+    }, 1000))
     console.groupEnd()
     plugins[base] = plugin
   }, 1000)


### PR DESCRIPTION
#217 is caused by a race condition, when the `pluginsWatcher.on('addDir'` fires earlier than a folder is fully moved from the temporary directory to the `plugins/node_modules` during the plugin installation.

This is an ugly fix, that just waits one second before attempting to load the plugin, assuming that one second would be enough to move the files. 