### PR TITLE
Fix typo in require memoizee

### DIFF
--- a/docs/plugins/cerebro-tools.md
+++ b/docs/plugins/cerebro-tools.md
@@ -20,7 +20,7 @@ const results = search(collection, term, toString);
 Use this function to reduce calls to external APIs.
 
 ```js
-const { memoize } = require('memoizee');
+const { memoize } = require('cerebro-tools');
 
 const fetchResults = require('path/to/fetchResults');
 

--- a/docs/plugins/cerebro-tools.md
+++ b/docs/plugins/cerebro-tools.md
@@ -20,7 +20,7 @@ const results = search(collection, term, toString);
 Use this function to reduce calls to external APIs.
 
 ```js
-const { memoize } = require('memoize');
+const { memoize } = require('memoizee');
 
 const fetchResults = require('path/to/fetchResults');
 


### PR DESCRIPTION
Hi, I've noticed a typo in the sample code when trying to create a plugin. This fixes it.
Thank you for your work!