### PR TITLE
Implement lightweight vim mode

### DIFF
--- a/app/main/components/KeyboardNav/index.js
+++ b/app/main/components/KeyboardNav/index.js
@@ -19,6 +19,17 @@ const moveSelectionTo = (elements, index) => {
   elements[nextIndex].focus()
 }
 
+const vimKeyCodes = {
+  h: 72,
+  j: 74,
+  k: 75,
+  l: 76
+}
+
+const isVimMode = (event) => (key) => (
+  vimKeyCodes[key] === event.keyCode && (event.metaKey || event.ctrlKey)
+)
+
 /**
  * Handler keydown in keyboard navigation component
  *
@@ -27,8 +38,9 @@ const moveSelectionTo = (elements, index) => {
  */
 const onKeyDown = (wrapper, event) => {
   const { target, keyCode } = event
-  if (keyCode === 37) {
-    // Move control back to main list when ← is clicked
+  const isVimKey = isVimMode(event)
+  if (keyCode === 37 || isVimKey('h')) {
+    // Move control back to main list when ← is clicked or cmd/ctrl+h
     const mainInput = document.querySelector('#main-input')
     const position = mainInput.value.length
     mainInput.focus()
@@ -37,7 +49,7 @@ const onKeyDown = (wrapper, event) => {
     event.stopPropagation()
     return false
   }
-  if (keyCode !== 40 && keyCode !== 38) {
+  if (keyCode !== 40 && keyCode !== 38 && !isVimKey('j') && !isVimKey('k')) {
     return false
   }
 
@@ -47,11 +59,11 @@ const onKeyDown = (wrapper, event) => {
   // Get index of currently focused element
   const index = Array.prototype.findIndex.call(focusable, (el) => el === target)
 
-  if (keyCode === 40) {
+  if (keyCode === 40 || isVimKey('j')) {
     // Select next focusable element when arrow down clicked
     moveSelectionTo(focusable, index + 1)
     event.stopPropagation()
-  } else if (keyCode === 38) {
+  } else if (keyCode === 38 || isVimKey('k')) {
     // Select previous focusable element when arrow down clicked
     moveSelectionTo(focusable, index - 1)
     event.stopPropagation()

--- a/app/main/components/KeyboardNavItem/index.js
+++ b/app/main/components/KeyboardNavItem/index.js
@@ -10,7 +10,7 @@ const KeyboardNavItem = ({ tagName, ...props }) => {
     if (props.onKeyDown) {
       props.onKeyDown(event)
     }
-    if (!event.defaultPrevented && event.keyCode === 13) {
+    if (!event.defaultPrevented && (event.keyCode === 79 && (event.metaKey || event.ctrlKey))) {
       onSelect()
     }
   }

--- a/app/main/containers/Search/index.js
+++ b/app/main/containers/Search/index.js
@@ -151,6 +151,37 @@ class Search extends Component {
     if (event.defaultPrevented) {
       return
     }
+
+    const keyActions = {
+      select: () => {
+        this.selectCurrent(event)
+      },
+      arrowRight: () => {
+        if (cursorInEndOfInut(event.target)) {
+          if (this.autocompleteValue()) {
+            // Autocomplete by arrow right only if autocomple value is shown
+            this.autocomplete(event)
+          } else {
+            focusPreview()
+            event.preventDefault()
+          }
+        }
+      },
+      arrowDown: () => {
+        this.props.actions.moveCursor(1)
+        event.preventDefault()
+      },
+      arrowUp: () => {
+        if (this.props.results.length > 0) {
+          this.props.actions.moveCursor(-1)
+        } else if (this.props.prevTerm) {
+          this.props.actions.updateTerm(this.props.prevTerm)
+        }
+        event.preventDefault()
+      }
+    }
+
+
     if (event.metaKey || event.ctrlKey) {
       if (event.keyCode === 67) {
         // Copy to clipboard on cmd+c
@@ -170,36 +201,37 @@ class Search extends Component {
           return this.selectItem(result)
         }
       }
+      // Lightweight vim-mode: cmd/ctrl + jklo
+      switch (event.keyCode) {
+        case 74:
+          keyActions.arrowDown()
+          break
+        case 75:
+          keyActions.arrowUp()
+          break
+        case 76:
+          keyActions.arrowRight()
+          break
+        case 79:
+          keyActions.select()
+          break
+      }
     }
     switch (event.keyCode) {
       case 9:
         this.autocomplete(event)
         break
       case 39:
-        if (cursorInEndOfInut(event.target)) {
-          if (this.autocompleteValue()) {
-            // Autocomplete by arrow right only if autocomple value is shown
-            this.autocomplete(event)
-          } else {
-            focusPreview()
-            event.preventDefault()
-          }
-        }
+        keyActions.arrowRight()
         break
       case 40:
-        this.props.actions.moveCursor(1)
-        event.preventDefault()
+        keyActions.arrowDown()
         break
       case 38:
-        if (this.props.results.length > 0) {
-          this.props.actions.moveCursor(-1)
-        } else if (this.props.prevTerm) {
-          this.props.actions.updateTerm(this.props.prevTerm)
-        }
-        event.preventDefault()
+        keyActions.arrowUp()
         break
       case 13:
-        this.selectCurrent(event)
+        keyActions.select()
         break
       case 27:
         this.props.actions.reset()


### PR DESCRIPTION
Implement [lightweight vim-mode](https://github.com/KELiON/cerebro/issues/170#issuecomment-286065838). Now you can use <kbd>cmd/ctrl+hjklo</kbd> for navigation instead of arrows and enter

Partially implement #170