### PR TITLE
Call fix-path

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,2 @@
-main.js
+./main.js
 webpack.config.*.js

--- a/app/background/background.js
+++ b/app/background/background.js
@@ -1,6 +1,8 @@
 import initializeRpc from './rpc/initialize'
 import { on } from 'lib/rpc/events'
 
+require('fix-path')()
+
 initializeRpc()
 
 // Handle `reload` rpc event and reload window

--- a/app/main/main.js
+++ b/app/main/main.js
@@ -1,14 +1,15 @@
-import path from 'path';
-import React from 'react';
-import { render } from 'react-dom';
-import { Provider } from 'react-redux';
-import store from './store';
-import Search from './containers/Search';
+import React from 'react'
+import { render } from 'react-dom'
+import { Provider } from 'react-redux'
+import store from './store'
+import Search from './containers/Search'
 import './css/global.css'
-import { initializePlugins } from 'lib/rpc/functions';
-import { on } from 'lib/rpc/events';
-import { updateTerm } from './actions/search';
-import config from '../lib/config';
+import { initializePlugins } from 'lib/rpc/functions'
+import { on } from 'lib/rpc/events'
+import { updateTerm } from './actions/search'
+import config from '../lib/config'
+
+require('fix-path')()
 
 /**
  * Change current theme
@@ -16,11 +17,11 @@ import config from '../lib/config';
  * @param  {String} src Absolute path to new theme css file
  */
 const changeTheme = (src) => {
-  document.getElementById('cerebro-theme').href = src;
-};
+  document.getElementById('cerebro-theme').href = src
+}
 
 // Set theme from config
-changeTheme(config.get('theme'));
+changeTheme(config.get('theme'))
 
 // Render main container
 render(
@@ -28,25 +29,22 @@ render(
     <Search />
   </Provider>,
   document.getElementById('root')
-);
+)
 
 // Initialize plugins
-initializePlugins();
+initializePlugins()
 
 // Handle `showTerm` rpc event and replace search term with payload
-on('showTerm', (term) => {
-  store.dispatch(updateTerm(term));
-});
+on('showTerm', (term) => store.dispatch(updateTerm(term)))
 
-on('update-downloaded', (payload) => {
+on('update-downloaded', () => (
   new Notification('Cerebro: update is ready to install', {
     body: 'New version is downloaded and will be automatically installed on quit'
   })
-});
-
+))
 
 // Handle `updateTheme` rpc event and change current theme
-on('updateTheme', changeTheme);
+on('updateTheme', changeTheme)
 
 // Handle `reload` rpc event and reload window
 on('reload', () => location.reload())

--- a/webpack.config.development.js
+++ b/webpack.config.development.js
@@ -12,12 +12,10 @@ const config = {
   entry: {
     background: [
       'webpack-hot-middleware/client?path=http://localhost:3000/__webpack_hmr',
-      'fix-path',
       './app/background/background',
     ],
     main: [
       'webpack-hot-middleware/client?path=http://localhost:3000/__webpack_hmr',
-      'fix-path',
       './app/main/main',
     ]
   },


### PR DESCRIPTION
Electron doesn't inherit the `$PATH` defined in dotfiles (.bashrc/.bash_profile/.zshrc/etc), so we should fix it for plugins