### PR TITLE
Switch to electrons getFileIcon on windows

### DIFF
--- a/app/lib/getFileIcon/windows.js
+++ b/app/lib/getFileIcon/windows.js
@@ -1,4 +1,4 @@
-const extractIcon = require('win-icon-extractor')
+import { remote } from 'electron'
 
 /**
  * Get system icon for file
@@ -7,5 +7,10 @@ const extractIcon = require('win-icon-extractor')
  * @return {Promise<String>} Promise resolves base64-encoded source of icon
  */
 export default function getFileIcon(path) {
-  return extractIcon(path)
+  return new Promise((accept, reject) => {
+    remote.app.getFileIcon(path, (err, icon) => {
+      if (err) return reject(err)
+      accept(icon.toDataURL())
+    });
+  });
 }

--- a/app/lib/getFileIcon/windows.js
+++ b/app/lib/getFileIcon/windows.js
@@ -11,6 +11,6 @@ export default function getFileIcon(path) {
     remote.app.getFileIcon(path, (err, icon) => {
       if (err) return reject(err)
       accept(icon.toDataURL())
-    });
-  });
+    })
+  })
 }

--- a/app/main/plugins/core/basic-apps/index.js
+++ b/app/main/plugins/core/basic-apps/index.js
@@ -14,7 +14,7 @@ const fn = ({ term, actions, display }) => {
   const result = search(appsList, term, toString).map(app => {
     const { id, path, name, description, icon } = app
     return {
-      icon: path,
+      icon,
       id: id || path,
       title: name,
       term: name,

--- a/app/main/plugins/core/basic-apps/windows.js
+++ b/app/main/plugins/core/basic-apps/windows.js
@@ -9,11 +9,13 @@ const parseFile = (filePath) => {
     const details = shell.readShortcutLink(filePath)
     return {
       path: details.target,
-      description: details.description
+      description: details.description,
+      icon: details.target
     }
   } catch (e) {
     return {
-      path: filePath
+      path: filePath,
+      icon: filePath
     }
   }
 }

--- a/app/package.json
+++ b/app/package.json
@@ -21,8 +21,6 @@
     "semver": "^5.3.0",
     "universal-analytics": "^0.4.8"
   },
-  "optionalDependencies": {
-    "win-icon-extractor": "^1.0.4"
-  },
+  "optionalDependencies": {},
   "devDependencies": {}
 }


### PR DESCRIPTION
Removed win-icon-extractor and switched to electrons getFileIcon, which works the same way without additional dependencies.

Also fixed linux icons support.