### PR TITLE
[Linux] Add binary name support during app search

### DIFF
--- a/app/main/plugins/core/basic-apps/linux.js
+++ b/app/main/plugins/core/basic-apps/linux.js
@@ -103,7 +103,14 @@ const findIcon = (icon) => {
   )).find(fs.existsSync)
 }
 
-export const toString = ({ name }) => `${name} ${getAbbr(name)}`
+export const toString = ({ name, exec }) => {
+  const binaryName = exec
+      .split('/')
+      .pop()
+      .split(' ')
+      .shift()
+  return `${name} ${getAbbr(name)} ${binaryName}`
+}
 
 export const formatPath = (filePath) => {
   const parsedData = parseDesktopFile(filePath, {


### PR DESCRIPTION
It works, while not perfect yet.
Ideally there should be support for search priorities. When match is found in app name - it should be higher that when it is found in binary name.

Technically implementation is similar to Windows.