### PR TITLE
Only show unique binaries in search results

### DIFF
--- a/app/main/plugins/core/basic-apps/index.js
+++ b/app/main/plugins/core/basic-apps/index.js
@@ -2,6 +2,7 @@ import React from 'react'
 import Preview from './Preview'
 import { search } from 'cerebro-tools'
 import uniq from 'lodash/uniq'
+import uniqBy from 'lodash/uniqBy'
 import initializeAsync from './initializeAsync'
 
 const { openApp, toString } = process.platform === 'win32'
@@ -12,10 +13,11 @@ let appsList = []
 
 const fn = ({ term, actions, display }) => {
   const result = search(appsList, term, toString).map(app => {
-    const { id, path, name, description, icon } = app
+    const { id, path, name, description, icon, exec, source } = app
     return {
       icon,
       id: id || path,
+      command: exec || source,
       title: name,
       term: name,
       subtitle: description || path,
@@ -31,7 +33,7 @@ const fn = ({ term, actions, display }) => {
       getPreview: () => <Preview name={name} path={path} icon={icon} />
     }
   })
-  display(result)
+  display(uniqBy(result, app => app.command))
 }
 
 export default {


### PR DESCRIPTION
Especially on Linux, it is very common to have multiple `*.desktop` files for the same application, 2 examples:
```
...
{ description: 'View current processes and monitor system state',
  exec: 'gnome-system-monitor',
  filename: 'gnome-system-monitor-kde.desktop',
  hidden: false,
  icon: '/usr/share/app-install/icons/utilities-system-monitor.svg',
  id: 'gnome-system-monitor-kde.desktop',
  name: 'GNOME System Monitor',
  path: '/usr/share/applications/gnome-system-monitor-kde.desktop' },
{ description: 'View current processes and monitor system state',
  exec: 'gnome-system-monitor',
  filename: 'gnome-system-monitor.desktop',
  hidden: false,
  icon: '/usr/share/app-install/icons/utilities-system-monitor.svg',
  id: 'gnome-system-monitor.desktop',
  name: 'System Monitor',
  path: '/usr/share/applications/gnome-system-monitor.desktop' },
...
{ description: 'Open your personal folder',
  exec: 'nemo %U',
  filename: 'nemo-home.desktop',
  hidden: false,
  icon: '/usr/share/app-install/icons/folder.png',
  id: 'nemo-home.desktop',
  name: 'Home Folder',
  path: '/usr/share/applications/nemo-home.desktop' },
{ description: 'Access and organize files',
  exec: 'nemo %U',
  filename: 'nemo.desktop',
  hidden: false,
  icon: '/usr/share/app-install/icons/system-file-manager.svg',
  id: 'nemo.desktop',
  name: 'Files',
  path: '/usr/share/applications/nemo.desktop' },
...
```

This PR introduces filtering applications by commands being executed so that each shows up in search results only once. Filtering upfront might decrease quality of search results, so this seems to be more appropriate solution to the problem.