### PR TITLE
Switch to SmartIcon in basic apps preview

### DIFF
--- a/app/main/plugins/core/basic-apps/Preview.js
+++ b/app/main/plugins/core/basic-apps/Preview.js
@@ -1,12 +1,13 @@
 import React, { PropTypes } from 'react'
 import FileDetails from 'main/components/FileDetails'
 import styles from './styles.css'
+import SmartIcon from 'main/components/SmartIcon'
 
 const Preview = ({ path, name, icon }) => (
   <div>
     {icon &&
       <div className={styles.previewIcon}>
-        <img src={icon} alt="" />
+        <SmartIcon path={icon} />
       </div>
     }
     <div className={styles.previewName}>{name}</div>


### PR DESCRIPTION
Switch to SmartIcon instead of img in application preview. This should fix #274.