### PR TITLE
Allow to use plugins with `default` key

### DIFF
--- a/app/main/plugins/externalPlugins.js
+++ b/app/main/plugins/externalPlugins.js
@@ -5,7 +5,13 @@ import { modulesDirectory, ensureFiles, settings } from 'lib/plugins'
 
 const requirePlugin = (pluginPath) => {
   try {
-    return window.require(pluginPath)
+    let plugin = window.require(pluginPath)
+    // Fallback for plugins with structure like `{default: {fn: ...}}`
+    const keys = Object.keys(plugin)
+    if (keys.length === 1 && keys[0] === 'default') {
+      plugin = plugin.default
+    }
+    return plugin
   } catch (error) {
     // catch all errors from plugin loading
     console.log('Error requiring', pluginPath)


### PR DESCRIPTION
It allows to use plugins without extra configuration and es2015 syntax for export/import. So, now plugin can do `export default { fn }` and it will work without `add-module-exports` babel plugin

