### PR TITLE
Feature/focus previous app

### DIFF
--- a/app/main/createWindow/toggleWindow.js
+++ b/app/main/createWindow/toggleWindow.js
@@ -1,3 +1,5 @@
+import { app } from 'electron'
+
 /**
  * Show or hide main window
  * @return {BrowserWindow} appWindow
@@ -5,6 +7,7 @@
 export default (appWindow) => {
   if (appWindow.isVisible()) {
     appWindow.hide()
+    app.hide()
   } else {
     appWindow.show()
     appWindow.focus()

--- a/app/main/plugins/core/plugins/getAvailablePlugins.js
+++ b/app/main/plugins/core/plugins/getAvailablePlugins.js
@@ -4,9 +4,7 @@ import { flow, map, sortBy } from 'lodash/fp'
  * API endpoint to search all cerebro plugins
  * @type {String}
  */
-// TODO: after ending beta-testing of new version – change back to registry.npmjs.com
-// const URL = 'https://registry.npmjs.com/-/v1/search?from=0&size=500&text=keywords:cerebro-plugin'
-const URL = 'https://api.npms.io/v2/search?from=0&size=250&q=keywords%3Acerebro-plugin,cerebro-extracted-plugin'
+const URL = 'https://registry.npmjs.com/-/v1/search?from=0&size=500&text=keywords:cerebro-plugin,cerebro-extracted-plugin'
 
 /**
  * Get all available plugins for Cerebro
@@ -24,6 +22,6 @@ export default () => (
           homepage: p.package.links.homepage,
           repo: p.package.links.repository
         }))
-      )(json.results)
+      )(json.objects)
     )
 )


### PR DESCRIPTION
Set focus back to previous application

Before if you focus in some input in browser and show/hide Cerebro – focus won't be restored in this input. Now it is 