### PR TITLE
Fix plugin updates watcher

### DIFF
--- a/app/main/plugins/externalPlugins.js
+++ b/app/main/plugins/externalPlugins.js
@@ -69,7 +69,7 @@ pluginsWatcher.on('addDir', (pluginPath) => {
 
     console.log('Loaded.')
     const requirePath = window.require.resolve(pluginPath)
-    const watcher = chokidar.watch(requirePath, { depth: 0 })
+    const watcher = chokidar.watch(pluginPath, { depth: 0 })
     watcher.on('change', debounce(() => {
       console.log(`[${base}] Update plugin`)
       delete window.require.cache[requirePath]


### PR DESCRIPTION
Watching full plugin path to file doesn't work because file is not updated by web pack, but delete and added back

