### PR TITLE
Ugly hack for main renderer/background race condition in plugin initialization

### DIFF
--- a/app/lib/rpc/functions/initializePlugins.js
+++ b/app/lib/rpc/functions/initializePlugins.js
@@ -6,7 +6,9 @@ const asyncInitializePlugins = wrap('initializePlugins')
 
 const initializePlugins = () => {
   // Call background initializers
-  asyncInitializePlugins()
+  // TODO: instead of timeout call initializeAsync of plugin
+  // only when this plugin is loaded in background
+  setTimeout(asyncInitializePlugins, 2000)
 
   // Call foreground initializers
   Object.keys(plugins).forEach(name => {


### PR DESCRIPTION
run initializeAsync for plugins only after 2 seconds when main render…er process is loaded

