### PR TITLE
Always restore focus in previous app on Mac

### DIFF
--- a/app/main/createWindow.js
+++ b/app/main/createWindow.js
@@ -128,6 +128,14 @@ export default ({ src, isDev }) => {
   // Set initial handler if it is needed
   handleCleanOnHideChange(config.get('cleanOnHide'))
 
+  // Restore focus in previous application
+  // MacOS only: https://github.com/electron/electron/blob/master/docs/api/app.md#apphide-macos
+  if (process.platform === 'darwin') {
+    mainWindow.on('hide', () => {
+      app.hide()
+    })
+  }
+
   // Show main window when user opens application, but it is already opened
   app.on('open-file', (event, path) => handleUrl(mainWindow, path))
   app.on('open-url', (event, path) => handleUrl(mainWindow, path))

--- a/app/main/createWindow/toggleWindow.js
+++ b/app/main/createWindow/toggleWindow.js
@@ -1,5 +1,3 @@
-import { app } from 'electron'
-
 /**
  * Show or hide main window
  * @return {BrowserWindow} appWindow
@@ -7,11 +5,6 @@ import { app } from 'electron'
 export default (appWindow) => {
   if (appWindow.isVisible()) {
     appWindow.hide()
-    if (process.platform === 'darwin') {
-      // Restore focus in previous application
-      // MacOS only: https://github.com/electron/electron/blob/master/docs/api/app.md#apphide-macos
-      app.hide()
-    }
   } else {
     appWindow.show()
     appWindow.focus()


### PR DESCRIPTION
Now it doesn't depend on way we hide the window

