### PR TITLE
support for portable mode

### DIFF
--- a/app/lib/config.js
+++ b/app/lib/config.js
@@ -10,7 +10,7 @@ const electronApp = remote ? remote.app : app
 // set data directory to ./userdata
 process.argv.forEach((arg) => {
   if (arg.toLowerCase() === '-p' || arg.toLowerCase() === '--portable') {
-    electronApp.setPath('userData', process.cwd() + '/userdata')
+    electronApp.setPath('userData', `${process.cwd()}/userdata`)
   }
 })
 

--- a/app/lib/config.js
+++ b/app/lib/config.js
@@ -8,11 +8,11 @@ const electronApp = remote ? remote.app : app
 
 // initiate portable mode
 // set data directory to ./userdata
-process.argv.forEach((arg, count) => {
- if (arg.toLowerCase() === '-p' || arg.toLowerCase() === '--portable') {
-    electronApp.setPath('userData', process.cwd() + '/userdata');
+process.argv.forEach((arg) => {
+  if (arg.toLowerCase() === '-p' || arg.toLowerCase() === '--portable') {
+    electronApp.setPath('userData', process.cwd() + '/userdata')
   }
-});
+})
 
 const CONFIG_FILE = `${electronApp.getPath('userData')}/config.json`
 
@@ -83,7 +83,7 @@ const set = (key, value) => {
   trackEvent({
     category: 'Settings',
     event: `Change ${key}`,
-    label: value,
+    label: value
   })
   if (ipcRenderer) {
     console.log('notify main process', key, value)

--- a/app/lib/config.js
+++ b/app/lib/config.js
@@ -6,6 +6,14 @@ import loadThemes from './loadThemes'
 
 const electronApp = remote ? remote.app : app
 
+// initiate portable mode
+// set data directory to ./userdata
+process.argv.forEach((arg, count) => {
+ if (arg.toLowerCase() === '-p' || arg.toLowerCase() === '--portable') {
+    electronApp.setPath('userData', process.cwd() + '/userdata');
+  }
+});
+
 const CONFIG_FILE = `${electronApp.getPath('userData')}/config.json`
 
 const defaultSettings = memoize(() => {


### PR DESCRIPTION
Added --portable switch based on the feature in TagSpaces to save app data in the install directory, allowing portable usage on USB drives.

https://github.com/tagspaces/tagspaces