### PR TITLE
Activate launched applications

### DIFF
--- a/app/main/components/Cerebro/index.js
+++ b/app/main/components/Cerebro/index.js
@@ -290,10 +290,10 @@ class Cerebro extends Component {
     this.props.actions.reset()
     trackSelectItem(item.plugin)
     const event = wrapEvent(realEvent)
-    item.onSelect(event)
     if (!event.defaultPrevented) {
       this.electronWindow.hide()
     }
+    item.onSelect(event)
   }
 
   /**


### PR DESCRIPTION
hiding electron window after `openExternal` leaves focus in cerebro application, instead of launched app. So, launching application after hiding cerebro window fixes it.

Fixing #369

