### PR TITLE
Fix desktop file validation bug in Ubuntu

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
           ]
         }
       ],
-      "category": "public.app-category.productivity"
+      "category": "Utility"
     },
     "mac": {
       "category": "public.app-category.productivity"


### PR DESCRIPTION
Fixes #363 and #352 
The category field needed to be set to a registered value defined by the [freedesktop.org spec](https://specifications.freedesktop.org/menu-spec/menu-spec-1.0.html#category-registry)
 Of all the given options 'Utility'  seemed like the best fit for cerebro.

This will fix the desktop file validation issue and also adds cerebro to the dash menu in Ubuntu
![cerebro](https://user-images.githubusercontent.com/7537349/28754572-a8e60c1e-7565-11e7-9def-1cc0b3aa6884.png)


