### PR TITLE
Added section for "Development" plugins

### DIFF
--- a/app/plugins/core/plugins/Preview/index.js
+++ b/app/plugins/core/plugins/Preview/index.js
@@ -68,6 +68,7 @@ class Preview extends Component {
       description,
       repo,
       isInstalled,
+      isDebugging,
       installedVersion,
       isUpdateAvailable
     } = this.props
@@ -90,7 +91,7 @@ class Preview extends Component {
             }
             {showSettings && <Settings name={name} settings={settings} />}
             {
-              !isInstalled &&
+              !isInstalled && !isDebugging &&
                 <ActionButton
                   action={this.pluginAction(name, 'install')}
                   text={runningAction === 'install' ? 'Installing...' : 'Install'}
@@ -141,6 +142,7 @@ Preview.propTypes = {
   repo: PropTypes.string,
   installedVersion: PropTypes.string,
   isInstalled: PropTypes.bool.isRequired,
+  isDebugging: PropTypes.bool,
   isUpdateAvailable: PropTypes.bool.isRequired,
   onComplete: PropTypes.func.isRequired,
 }

--- a/app/plugins/core/plugins/getDebuggingPlugins.js
+++ b/app/plugins/core/plugins/getDebuggingPlugins.js
@@ -1,0 +1,19 @@
+import path from 'path'
+import { modulesDirectory } from 'lib/plugins'
+import { readdir, lstatSync } from 'fs'
+
+const isSymlink = file => lstatSync(path.join(modulesDirectory, file)).isSymbolicLink()
+
+/* Get list of all plugins that are currently in debugging mode.
+ * These plugins are symlinked by [create-cerebro-plugin](https://github.com/KELiON/create-cerebro-plugin)
+ *
+ * @return {Promise<Object>}
+ */
+export default () => new Promise((resolve, reject) => {
+  readdir(modulesDirectory, (err, files) => {
+    if (err) {
+      return reject(err)
+    }
+    resolve(files.filter(isSymlink))
+  })
+})

--- a/app/plugins/core/plugins/index.js
+++ b/app/plugins/core/plugins/index.js
@@ -13,6 +13,7 @@ import * as statusBar from '../../../main/actions/statusBar'
 
 const toString = ({ name, description }) => [name, description].join(' ')
 const categories = [
+  ['Development', plugin => plugin.isDebugging],
   ['Updates', plugin => plugin.isUpdateAvailable],
   ['Installed', plugin => plugin.isInstalled],
   ['Available', plugin => plugin.name],

--- a/app/plugins/core/plugins/loadPlugins.js
+++ b/app/plugins/core/plugins/loadPlugins.js
@@ -1,6 +1,7 @@
 import { memoize } from 'cerebro-tools'
 import availablePlugins from './getAvailablePlugins'
 import getInstalledPlugins from './getInstalledPlugins'
+import getDebuggingPlugins from './getDebuggingPlugins'
 import semver from 'semver'
 
 const maxAge = 5 * 60 * 1000
@@ -14,16 +15,32 @@ const parseVersion = (version) => (
 export default () => (
   Promise.all([
     getAvailablePlugins(),
-    getInstalledPlugins()
-  ]).then(([available, installed]) => available.map(plugin => {
-    const installedVersion = parseVersion(installed[plugin.name])
-    const isInstalled = !!installed[plugin.name]
-    const isUpdateAvailable = isInstalled && semver.gt(plugin.version, installedVersion)
-    return {
-      ...plugin,
-      installedVersion,
-      isInstalled,
-      isUpdateAvailable
-    }
-  }))
+    getInstalledPlugins(),
+    getDebuggingPlugins()
+  ]).then(([available, installed, debuggingPlugins]) => {
+    const listOfAvailablePlugins = available.map((plugin) => {
+      const installedVersion = parseVersion(installed[plugin.name])
+      const isInstalled = !!installed[plugin.name]
+      const isUpdateAvailable = isInstalled && semver.gt(plugin.version, installedVersion)
+      return {
+        ...plugin,
+        installedVersion,
+        isInstalled,
+        isUpdateAvailable
+      }
+    })
+    console.log(debuggingPlugins)
+    const listOfDebuggingPlugins = debuggingPlugins.map(name => ({
+      name,
+      description: '',
+      version: 'dev',
+      isInstalled: false,
+      isUpdateAvailable: false,
+      isDebugging: true
+    }))
+    return [
+      ...listOfAvailablePlugins,
+      ...listOfDebuggingPlugins
+    ]
+  })
 )


### PR DESCRIPTION
Resolving #376.

Now plugins, that are currently in development (`yarn start` from create-cerebro-plugin is working in plugin directory) are shown in separate section. It could be useful for development plugins with settings:

![screen shot 2017-08-09 at 17 59 18](https://user-images.githubusercontent.com/594298/29131262-a3faaff6-7d2c-11e7-9373-53770ad6cbbb.png)
