### PR TITLE
Restore focus to previous window on blur/hide (production only)

### DIFF
--- a/app/main/createWindow/toggleWindow.js
+++ b/app/main/createWindow/toggleWindow.js
@@ -4,6 +4,8 @@
  */
 export default (appWindow) => {
   if (appWindow.isVisible()) {
+    appWindow.blur() // once for blurring the content of the window(?)
+    appWindow.blur() // twice somehow restores focus to prev foreground window
     appWindow.hide()
   } else {
     appWindow.show()


### PR DESCRIPTION
Fix for #405, only tested on Windows.

This only works for production environment, because of a check in `cerebro\app\main\createWindow.js` (line 60).

