### PR TITLE
Pass 'settings' object to plugins on initalize() and initializeAsync()

### DIFF
--- a/app/background/background.js
+++ b/app/background/background.js
@@ -2,8 +2,7 @@ import React from 'react'
 import ReactDOM from 'react-dom'
 import plugins from 'plugins'
 import { on, send } from 'lib/rpc'
-import { modulesDirectory } from 'lib/plugins'
-import { getSettings } from 'lib/initializePlugins'
+import { settings as pluginSettings, modulesDirectory } from 'lib/plugins'
 
 require('fix-path')()
 
@@ -29,7 +28,7 @@ on('initializePluginAsync', ({ name }) => {
         name,
         data,
       })
-    }, getSettings(name))
+    }, pluginSettings.getUserSettings(name))
   } catch (err) {
     console.log('Failed', err)
   }

--- a/app/background/background.js
+++ b/app/background/background.js
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom'
 import plugins from 'plugins'
 import { on, send } from 'lib/rpc'
 import { modulesDirectory } from 'lib/plugins'
+import { getSettings } from 'lib/initializePlugins'
 
 require('fix-path')()
 
@@ -28,7 +29,7 @@ on('initializePluginAsync', ({ name }) => {
         name,
         data,
       })
-    })
+    }, getSettings(name))
   } catch (err) {
     console.log('Failed', err)
   }

--- a/app/lib/initializePlugins.js
+++ b/app/lib/initializePlugins.js
@@ -1,12 +1,24 @@
 import { on, send } from 'lib/rpc'
 import plugins from 'plugins'
+import { settings as pluginSettings } from 'lib/plugins'
+
+export const getSettings = (name) => {
+  const settings = pluginSettings.get(name) || {}
+  if (plugins[name].settings) {
+    // Provide default values if nothing is set by user
+    Object.keys(plugins[name].settings).forEach((key) => {
+      settings[key] = settings[key] || plugins[name].settings[key].defaultValue
+    })
+  }
+  return settings
+}
 
 export const initializePlugin = (name) => {
   const { initialize, initializeAsync } = plugins[name]
   if (initialize) {
     // Foreground plugin initialization
     try {
-      initialize()
+      initialize(getSettings(name))
     } catch (e) {
       console.error(`Failed to initialize plugin: ${name}`, e)
     }

--- a/app/lib/initializePlugins.js
+++ b/app/lib/initializePlugins.js
@@ -2,23 +2,12 @@ import { on, send } from 'lib/rpc'
 import plugins from 'plugins'
 import { settings as pluginSettings } from 'lib/plugins'
 
-export const getSettings = (name) => {
-  const settings = pluginSettings.get(name) || {}
-  if (plugins[name].settings) {
-    // Provide default values if nothing is set by user
-    Object.keys(plugins[name].settings).forEach((key) => {
-      settings[key] = settings[key] || plugins[name].settings[key].defaultValue
-    })
-  }
-  return settings
-}
-
 export const initializePlugin = (name) => {
   const { initialize, initializeAsync } = plugins[name]
   if (initialize) {
     // Foreground plugin initialization
     try {
-      initialize(getSettings(name))
+      initialize(pluginSettings.getUserSettings(name))
     } catch (e) {
       console.error(`Failed to initialize plugin: ${name}`, e)
     }

--- a/app/lib/plugins/settings/get.js
+++ b/app/lib/plugins/settings/get.js
@@ -1,7 +1,7 @@
 import config from 'lib/config'
 import plugins from 'plugins'
 
-const getSettings = (pluginName) => config.get('plugins')[pluginName] || {}
+const getSettings = pluginName => config.get('plugins')[pluginName] || {}
 
 const getUserSettings = (pluginName) => {
   const settings = getSettings(pluginName)

--- a/app/lib/plugins/settings/get.js
+++ b/app/lib/plugins/settings/get.js
@@ -1,3 +1,17 @@
 import config from 'lib/config'
+import plugins from 'plugins'
 
-export default pluginName => config.get('plugins')[pluginName] || {}
+const getSettings = (pluginName) => config.get('plugins')[pluginName] || {}
+
+const getUserSettings = (pluginName) => {
+  const settings = getSettings(pluginName)
+  if (plugins[pluginName].settings) {
+    // Provide default values if nothing is set by user
+    Object.keys(plugins[pluginName].settings).forEach((key) => {
+      settings[key] = settings[key] || plugins[pluginName].settings[key].defaultValue
+    })
+  }
+  return settings
+}
+
+export default getUserSettings

--- a/app/lib/plugins/settings/index.js
+++ b/app/lib/plugins/settings/index.js
@@ -1,4 +1,4 @@
-import get from './get'
+import getUserSettings from './get'
 import validate from './validate'
 
-export default { get, validate }
+export default { getUserSettings, validate }

--- a/app/main/actions/search.js
+++ b/app/main/actions/search.js
@@ -1,7 +1,8 @@
 import plugins from 'plugins'
 import config from 'lib/config'
 import { shell, clipboard, remote } from 'electron'
-import { settings as pluginSettings } from 'lib/plugins'
+import { getSettings } from 'lib/initializePlugins'
+
 import store from '../store'
 
 import {
@@ -29,17 +30,6 @@ const DEFAULT_SCOPE = {
     replaceTerm: term => store.dispatch(updateTerm(term)),
     hideWindow: () => remote.getCurrentWindow().hide()
   }
-}
-
-const getSettings = (name) => {
-  const settings = pluginSettings.get(name) || {}
-  if (plugins[name].settings) {
-    // Provide default values if nothing is set by user
-    Object.keys(plugins[name].settings).forEach((key) => {
-      settings[key] = settings[key] || plugins[name].settings[key].defaultValue
-    })
-  }
-  return settings
 }
 
 /**

--- a/app/main/actions/search.js
+++ b/app/main/actions/search.js
@@ -1,7 +1,7 @@
 import plugins from 'plugins'
 import config from 'lib/config'
 import { shell, clipboard, remote } from 'electron'
-import { getSettings } from 'lib/initializePlugins'
+import { settings as pluginSettings } from 'lib/plugins'
 
 import store from '../store'
 
@@ -47,7 +47,7 @@ const eachPlugin = (term, display) => {
         hide: id => store.dispatch(hideElement(`${name}-${id}`)),
         update: (id, result) => store.dispatch(updateElement(`${name}-${id}`, result)),
         display: payload => display(name, payload),
-        settings: getSettings(name)
+        settings: pluginSettings.getUserSettings(name)
       })
     } catch (error) {
       // Do not fail on plugin errors, just log them to console

--- a/test/actions/search.spec.js
+++ b/test/actions/search.spec.js
@@ -22,9 +22,10 @@ const actions = searchInjector({
   electron: {},
   plugins: pluginsMock,
   'lib/config': {},
-  'lib/plugins': {
-    get: () => undefined
-  }
+  // 'lib/plugins': {
+  //   get: () => undefined
+  // },
+  'lib/initializePlugins': {}
 })
 
 describe('reset', () => {

--- a/test/actions/search.spec.js
+++ b/test/actions/search.spec.js
@@ -22,10 +22,9 @@ const actions = searchInjector({
   electron: {},
   plugins: pluginsMock,
   'lib/config': {},
-  // 'lib/plugins': {
-  //   get: () => undefined
-  // },
-  'lib/initializePlugins': {}
+  'lib/plugins': {
+    getUserSettings: () => undefined
+  }
 })
 
 describe('reset', () => {


### PR DESCRIPTION
Make `settings` object available on initialize(Async) like so:
```
const initialize = (settings) => {
  console.log(settings)
}
```
and
```
const initializeAsync = (cb, settings) => {
  console.log(settings)
}
```

Still allows backwards compatibility:
`const initialize = () => { }` and `const initializeAsync = (cb) => { }` should still work