### PR TITLE
Fix/restore focus windows (select/escape)

### DIFF
--- a/app/main/components/Cerebro/index.js
+++ b/app/main/components/Cerebro/index.js
@@ -247,6 +247,8 @@ class Cerebro extends Component {
         break
       case 27:
         this.props.actions.reset()
+        this.electronWindow.blur() // Needs to be blurred twice on Windows
+        this.electronWindow.blur() // To restore focus correctly
         this.electronWindow.hide()
         break
     }
@@ -291,8 +293,8 @@ class Cerebro extends Component {
     trackSelectItem(item.plugin)
     const event = wrapEvent(realEvent)
     if (!event.defaultPrevented) {
-      this.electronWindow.blur() // Windows needs blurring to happen twice For
-      this.electronWindow.blur() // Some reason
+      this.electronWindow.blur() // Needs to be blurred twice on Windows
+      this.electronWindow.blur() // To restore focus correctly
       this.electronWindow.hide()
     }
     item.onSelect(event)

--- a/app/main/components/Cerebro/index.js
+++ b/app/main/components/Cerebro/index.js
@@ -291,6 +291,8 @@ class Cerebro extends Component {
     trackSelectItem(item.plugin)
     const event = wrapEvent(realEvent)
     if (!event.defaultPrevented) {
+      this.electronWindow.blur() // Windows needs blurring to happen twice For
+      this.electronWindow.blur() // Some reason
       this.electronWindow.hide()
     }
     item.onSelect(event)


### PR DESCRIPTION
Add focus restoring on Windows in other scenarios. Focus also restored when:
* selecting a result
* pressing escape