### PR TITLE
Add extension to .eslintrc

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -34,11 +34,7 @@
     "jsx-a11y/no-static-element-interactions": "off",
     "jsx-a11y/label-has-for": "off"
   },
-  "plugins": [
-    "jsx-a11y",
-    "import",
-    "react"
-  ],
+  "plugins": ["jsx-a11y", "import", "react"],
   "settings": {
     "import/core-modules": "electron",
     "import/resolver": {


### PR DESCRIPTION
Hello, maintainers. Thank you for the nice app.

### Overview
It is not a critical fix, but .eslintrc without extension is deprecated ([https://eslint.org/docs/user-guide/configuring#configuration-file-formats](https://eslint.org/docs/user-guide/configuring#configuration-file-formats))

### Changes
Add .json extension to .eslintrc
